### PR TITLE
Removed extra character after extension

### DIFF
--- a/Discovery/Web-Content/raft-large-files.txt
+++ b/Discovery/Web-Content/raft-large-files.txt
@@ -24337,7 +24337,7 @@ classViewAds.asp
 classadmin.asp
 classdetail.asp
 classes.zip
-classes.zip,
+classes.zip
 classic.html
 classified_dump.php
 classifieds.html


### PR DESCRIPTION
I've removed the comma after the extension ".zip"